### PR TITLE
Fix playback from unwatched views, have onDeck sorted by date

### DIFF
--- a/default.py
+++ b/default.py
@@ -3849,7 +3849,7 @@ def shelf( server_list=None ):
                 WINDOW.clearProperty("Plexbmc.LatestEpisode.1.Path" )
                 continue
 
-            s_url="PlayMedia(plugin://plugin.video.plexbmc?url=%s&mode=%s%s)" % ( getLinkURL('http://'+server_address,media,server_address), _MODE_PLAYSHELF, aToken)
+            s_url="PlayMedia(plugin://plugin.video.plexbmc?url=%s&mode=%s&t=%s%s)" % ( getLinkURL('http://'+server_address,media,server_address), _MODE_PLAYSHELF, randomNumber, aToken)
             s_thumb="http://"+server_address+media.get('grandparentThumb','')
 
             WINDOW.setProperty("Plexbmc.LatestEpisode.%s.Path" % seasonCount, s_url )

--- a/default.py
+++ b/default.py
@@ -2434,7 +2434,7 @@ def getContent( url ):
 
     if view_group == "movie":
         printDebug( "This is movie XML, passing to Movies")
-        if not (lastbit.startswith('recently') or lastbit.startswith('newest')):
+        if not (lastbit.startswith('recently') or lastbit.startswith('newest') or lastbit.startswith('onDeck')):
             xbmcplugin.addSortMethod(pluginhandle,xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE )
         Movies(url, tree)
     elif view_group == "show":

--- a/default.py
+++ b/default.py
@@ -1682,7 +1682,10 @@ def TVEpisodes( url, tree=None ):
 
         extraData['mode']=_MODE_PLAYLIBRARY
         # http:// <server> <path> &mode=<mode> &t=<rnd>
-        u="http://%s%s?t=%s" % (server, extraData['key'], randomNumber)
+        separator = "?"
+        if "?" in extraData['key']:
+            separator = "&"
+        u="http://%s%s%st=%s" % (server, extraData['key'], separator, randomNumber)
 
         addGUIItem(u,details,extraData, context, folder=False)
 
@@ -2991,7 +2994,10 @@ def movieTag(url, server, tree, movie, randomNumber):
         context=None
     # http:// <server> <path> &mode=<mode> &t=<rnd>
     extraData['mode']=_MODE_PLAYLIBRARY
-    u="http://%s%s?t=%s" % (server, extraData['key'], randomNumber)
+    separator = "?"
+    if "?" in extraData['key']:
+        separator = "&"
+    u="http://%s%s%st=%s" % (server, extraData['key'], separator, randomNumber)
 
     addGUIItem(u,details,extraData,context,folder=False)
     return

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -92,5 +92,6 @@
 	<string id="30090">Teens</string>
 	<string id="30091">Adults</string>
 	<string id="30092">Use menu for shared sections</string>
-	<string id="30093">Cache Data</string>
+    <string id="30093">Cache Data</string>
+    <string id="30094">Both</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -50,7 +50,7 @@
 
     <category label="30020" > <!-- Look and feel -->
         <setting id="secondary" type="bool" label="30003" default="true"/>
-		<setting id="homeshelf" type="enum" label="30072" lvalues="30073|30074" default="0" />
+		<setting id="homeshelf" type="enum" label="30072" lvalues="30073|30074|30094" default="0" />
         <setting id="channelview" type="bool" label="30042" default="false"/>
         <setting id="flatten" type="enum" label="30043" lvalues="30053|30058|30059" default="0"/>
         <setting id="hide_shared" type="bool" label="30092" default="false"/>


### PR DESCRIPTION
unwatched playback:
Playing from an unwatched view generated a video url like this:
http://server:32400/blah?unwatched=1?t=random

So the code checks if a ? is already in the address and uses & if it's the case, to get this:
http://server:32400/blah?unwatched=1&t=random

onDeck sorting:
onDeck was not in the decision list to add or not the title sorting flag to the plugin output list. Added
