### PR TITLE
Remote sections are now retrieved by fullshelf()

### DIFF
--- a/default.py
+++ b/default.py
@@ -1821,7 +1821,7 @@ def getAudioSubtitlesMedia( server, tree, full=False ):
     extra={}
     
     timings = tree.find('Video')
-    if timings:
+    if timings is not None:
         media_type="video"
     else:
         timings = tree.find('Track')
@@ -1967,7 +1967,7 @@ def playPlaylist ( server, data ):
     
     tree = getXML(server+data['extra'].get('album')+"/children")
     
-    if not tree:
+    if tree is None:
         return
         
     TrackTags=tree.findall('Track')
@@ -4092,6 +4092,7 @@ def fullShelf(server_list={}):
 
                 for section in sections:
                     recent_url = section.get('address') + section.get("path") + "/recentlyAdded"
+                    _PARAM_TOKEN = section.get('token', '')
                     tree = getURL(recent_url)
                     tree = etree.fromstring(tree)
 

--- a/default.py
+++ b/default.py
@@ -4095,6 +4095,7 @@ def fullShelf(server_list={}):
                     _PARAM_TOKEN = section.get('token', '')
                     tree = getURL(recent_url)
                     tree = etree.fromstring(tree)
+                    _PARAM_TOKEN = server_details.get('token', '')
 
                     '''
                     eetee = etree.ElementTree()
@@ -4150,9 +4151,10 @@ def fullShelf(server_list={}):
                 for section in sections:
 
                     ondeck_url = section.get('address') + section.get("path") + "/onDeck"
+                    _PARAM_TOKEN = section.get('token', '')
                     tree = getURL(ondeck_url)
                     tree = etree.fromstring(tree)
-
+                    _PARAM_TOKEN = server_details.get('token', '')
                     '''
                     eetee = etree.ElementTree()
                     eetee._setroot(tree)


### PR DESCRIPTION
When a section contains a directory from a remote server the remote access token must be used for the request. 
- fixed two minor warnings.
