### PR TITLE
No connection through proxy

### DIFF
--- a/default.py
+++ b/default.py
@@ -240,6 +240,16 @@ g_txheaders = {
               'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US;rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 ( .NET CLR 3.5.30729)',
               }
 
+#Checking for proxy setting
+
+if __settings__.getSetting("proxy_enabled") == "true":
+	g_proxy_enabled = True
+	g_proxy_host = __settings__.getSetting("proxy_host")
+	g_proxy_port = __settings__.getSetting("proxy_port")
+else:
+	g_proxy_enabled = False
+
+
 #Set up holding variable for session ID
 global g_sessionID
 g_sessionID=None
@@ -694,7 +704,11 @@ def getMyPlexURL(url_path, renew=False, suppress=True):
     printDebug("url = "+MYPLEX_SERVER+url_path)
 
     try:
-        conn = httplib.HTTPSConnection(MYPLEX_SERVER, timeout=5)
+        if g_proxy_enabled:
+          conn = httplib.HTTPSConnection(g_proxy_host, g_proxy_port, timeout=5)
+          conn._set_tunnel(MYPLEX_SERVER)
+        else:
+          conn = httplib.HTTPSConnection(MYPLEX_SERVER, timeout=5)
         conn.request("GET", url_path+"?X-Plex-Token="+getMyPlexToken(renew))
         data = conn.getresponse()
         if ( int(data.status) == 401 )  and not ( renew ):
@@ -792,7 +806,11 @@ def getNewMyPlexToken(suppress=True, title="Error"):
                     'Authorization': "Basic %s" % base64string}
 
     try:
-        conn = httplib.HTTPSConnection(MYPLEX_SERVER)
+        if g_proxy_enabled:
+          conn = httplib.HTTPSConnection(g_proxy_host, g_proxy_port, timeout=5)
+          conn._set_tunnel(MYPLEX_SERVER)
+        else:
+          conn = httplib.HTTPSConnection(MYPLEX_SERVER, timeout=5)
         conn.request("POST", "/users/sign_in.xml", txdata, myplex_headers)
         data = conn.getresponse()
 
@@ -845,7 +863,11 @@ def getURL(url, suppress=True, type="GET", popup=0):
 
         printDebug("url = "+url)
         printDebug("header = "+str(authHeader))
-        conn = httplib.HTTPConnection(server, timeout=8)
+        if g_proxy_enabled:
+          conn = httplib.HTTPConnection(g_proxy_host, g_proxy_port, timeout=5)
+          conn._set_tunnel(server)
+        else:
+          conn = httplib.HTTPConnection(MYPLEX_SERVER, timeout=5)
         conn.request(type, urlPath, headers=authHeader)
         data = conn.getresponse()
         

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -98,4 +98,7 @@
 	<string id="30095">Use full-res thumbs</string>
 	<string id="30096">Use full-res fanart</string>
 	<string id="30097">Hide watched recently added items</string>
+	<string id="30098">Use proxy</string>
+	<string id="30099">Proxy host</string>
+	<string id="30100">Proxy port</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,9 @@
     <setting id="discovery" type="enum" label="30004" lvalues="30094|30070" default="1"/>
     <setting id="ipaddress" type="text" label="30000" default="localhost" visible="eq(-1,0)" enable="eq(-1,0)"/>
     <setting id="port" type="text" label="30030" default="32400" visible="eq(-2,0)" enable="eq(-2,0)"/>
+    <setting id="proxy_enabled" type="bool" label="30098" default="false"/>
+    <setting id="proxy_host" type="text" label="30099" default="" visible="eq(-1,true)" enable="eq(-1,true)"/>
+    <setting id="proxy_port" type="text" label="30100" default="" visible="eq(-2,true)" enable="eq(-2,true)"/>
     <!--<setting type="sep" />-->
     <setting id="selectMaster" label="30026" type="action" action="RunScript(plugin.video.plexbmc, master)" />
     <setting id="masterServer" label="30071" type="text" default="" />


### PR DESCRIPTION
Hi there. Nice work with this addon, it works for me for my local plex library, but when I try to connect to my home library from work nothing happens: I can see only "Refresh Data" and "myplex Queue"
I've configured it with my plex login/pass. Also I'm using proxy which is correctly entered in XBMC settings and works for xmbc itself

I'm using the 3.4.6~beta3, also tried 3.4.6~beta1.

Any thoughts?

Oh, and the library is accessible through native plex app, so the server and ports are ok I suppose 

Well... I enabled debug and checked log:
Unable to connect to my.plexapp.com Reason: timed out

So it seems not to respect xbmc proxy setting

I've tunneled the 32400 port through ssh to my NAS, and I can see in logs that the plugin gets an answer about the library, but then it tries to connect to plex servers and fails
