### PR TITLE
Reduce PMS Calls by only requesting shelf data for visible libraries (take 2)

### DIFF
--- a/resources/lib/plexserver.py
+++ b/resources/lib/plexserver.py
@@ -585,6 +585,7 @@ class plex_section:
         self.art = None
         self.type = None
         self.location = "local"
+        self.skinID = None
 
         if data is not None:
             self.populate(data)
@@ -649,3 +650,9 @@ class plex_section:
         if self.type == 'photo':
             return True
         return False
+
+    def get_skinID(self):
+        return self.skinID
+
+    def set_skinID(self, data=None):
+        self.skinID = data


### PR DESCRIPTION
Adds skinID to section class, this is used later to see if the current section/library is visible
Adds maxItem_recent_ondeck to fullshelf in to maybe add later to settins

If section\Library is visible only then will PMS calls be made to populate the shelf.

If section\Library is episode based loads more items (50, plex max is 100 but 50 seems a good compromise for cpu and network speed) to try and fill out the row in case full seasons are added (as code condenses to seasons and US standard of 10 to 24 shows a season jumps over current 15), but because of the maxItem_recent_ondeck variable, won't add more if this scenario doesn't exist
