### PR TITLE
Add support for encrypted Plex servers

### DIFF
--- a/resources/lib/plex.py
+++ b/resources/lib/plex.py
@@ -293,7 +293,7 @@ class Plex:
                     printDebug.info("GDM discovery completed")
 
                     for device in gdm_server_name:
-                        new_server=PlexMediaServer(name=device['serverName'],uri="http://"+settings.get_setting('ipaddress')+":"+settings.get_setting('port'), discovery='discovery', uuid=device['uuid'])
+                        new_server=PlexMediaServer(name=device['serverName'],uri="http://"+device['server']+":"+device['port'], discovery='discovery', uuid=device['uuid'])
                         new_server.set_user(self.effective_user)
                         new_server.set_token(self.effective_token)
 
@@ -385,9 +385,12 @@ class Plex:
                 self.server_list[server.get_uuid()]=server
         else:
             printDebug.info("Found existing server %s %s" % (existing.get_name(), existing.get_uuid()))
-            existing.set_best_uri(server.get_uri())
-            existing.refresh()
-            self.server_list[existing.get_uuid()]=existing
+
+            # GDM cannot (easily) handle encrypted servers. so leave them be
+            if not existing.is_encrypted:
+                existing.set_best_uri(server.get_uri())
+                existing.refresh()
+                self.server_list[existing.get_uuid()]=existing
 
         return 
 

--- a/resources/lib/plexbmc.py
+++ b/resources/lib/plexbmc.py
@@ -1128,7 +1128,7 @@ def playLibraryMedia( vids, override=False, force=None, full_data=False, shelf=F
     if protocol == "file":
         printDebug.debug( "We are playing a local file")
         playurl=url.split(':',1)[1]
-    elif protocol == "http":
+    elif protocol == "http" or protocol == "https":
         printDebug.debug( "We are playing a stream")
         if override:
             printDebug.debug( "We will be transcoding the stream")
@@ -1193,7 +1193,7 @@ def playLibraryMedia( vids, override=False, force=None, full_data=False, shelf=F
     # record the playing file and server in the home window
     # so that plexbmc helper can find out what is playing
     WINDOW = xbmcgui.Window( 10000 )
-    WINDOW.setProperty('plexbmc.nowplaying.server', server.get_location())
+    WINDOW.setProperty('plexbmc.nowplaying.server', server.get_uri())
     WINDOW.setProperty('plexbmc.nowplaying.id', id)
 
     #Set a loop to wait for positive confirmation of playback

--- a/resources/lib/plexgdm.py
+++ b/resources/lib/plexgdm.py
@@ -211,6 +211,8 @@ class plexgdm:
                             update['uuid'] = each.split(':')[1].strip()
                         elif "Name:" in each:
                             update['serverName'] = each.split(':')[1].strip()
+                        elif "Host:" in each:
+                            update['host'] = each.split(':')[1].strip()
                         elif "Port:" in each:
                             update['port'] = each.split(':')[1].strip()
                         elif "Updated-At:" in each:

--- a/resources/lib/plexserver.py
+++ b/resources/lib/plexserver.py
@@ -12,35 +12,26 @@ import requests
 
 printDebug=printDebug("PleXBMC", "plexserver")
 
-DEFAULT_PORT="32400"
-
 printDebug.debug("Using Requests version for HTTP: %s" % requests.__version__)
 
 class PlexMediaServer:
 
-    def __init__(self, uuid=None, name=None, address=None, port=32400, token=None, discovery=None, class_type='primary' ):
+    def __init__(self, uuid=None, name=None, uri=None, token=None, discovery=None, class_type='primary' ):
 
         self.__revision = REQUIRED_REVISION
-        self.protocol="http"
         self.uuid=uuid
         self.server_name=name
         self.discovery=discovery
-        self.local_address=[]
-        self.local_port=None
-        self.external_address=None
-        self.external_port=None
-        self.access_address=None
-        self.access_port=None
+        self.local_uri=[]
+        self.external_uri=None
+        self.access_uri=None
 
         if self.discovery == "myplex":
-            self.external_address=address
-            self.external_port=port
+            self.external_uri=uri
         elif self.discovery == "discovery":
-            self.local_address=[address]
-            self.local_port=port
+            self.local_uri=uri
         
-        self.access_address=address
-        self.access_port=port
+        self.access_uri=uri
 
         self.section_list=[]
         self.token=token
@@ -68,8 +59,7 @@ class PlexMediaServer:
     def get_details(self):
 
         return {'serverName': self.server_name,
-                'server'    : self.get_address(),
-                'port'      : self.get_port(),
+                'uri   '    : self.get_uri(),
                 'discovery' : self.discovery,
                 'token'     : self.token ,
                 'uuid'      : self.uuid,
@@ -127,17 +117,14 @@ class PlexMediaServer:
     def get_name(self):
         return self.server_name
 
-    def get_address(self):
-        return self.access_address
-
-    def get_port(self):
-        return self.access_port
+    def get_uri(self):
+        return self.access_uri
 
     def get_url_location(self):
-        return '%s://%s:%s' % ( self.protocol, self.get_address(), self.get_port())
+        return self.access_uri
 
     def get_location(self):
-        return '%s:%s' % ( self.get_address(), self.get_port())
+        return urlparse.urlparse(self.access_uri).netloc
 
     def get_token(self):
         return self.token
@@ -145,47 +132,15 @@ class PlexMediaServer:
     def get_discovery(self):
         return self.discovery
 
-    def add_local_address(self, address):
-        self.local_address=address.split(',')
+    def set_local_uri(self, uris):
+        self.local_uri=uris
 
-    def set_best_address(self, ipaddress):
-        if self.external_address == ipaddress:
-            printDebug.debug("new [%s] == existing [%s]" % (ipaddress, self.external_address))
-            self.access_address=self.external_address
-            self.access_port=self.external_port
-            return
-        else:
-            printDebug("new [%s] != existing [%s]" % (ipaddress, self.external_address))
+    def set_best_address(self, uri):
+        self.access_uri = uri
 
-        for test_address in self.local_address:
-            if test_address == ipaddress:
-                printDebug.debug("new [%s] == existing [%s]" % (ipaddress, test_address))
-                self.access_address = test_address
-                self.access_port=32400
-                return
-            else:
-                printDebug.debug("new [%s] != existing [%s]" % (ipaddress, test_address))
-
-        printDebug.debug("new [%s] is unknown.  Possible uuid clash?" % ipaddress)
-        printDebug.debug("Will use this address for this object, as a last resort")
-        self.access_address = ipaddress
-        self.access_port = 32400
-        
-        return
-
-    def find_address_match(self, ipaddress,port):
-        printDebug.debug("Checking [%s:%s] against [%s:%s]" % ( ipaddress, port, self.access_address, self.access_port))
-        if "%s:%s" % (ipaddress, port) == "%s:%s" % (self.access_address, self.access_port):
+    def find_uri_match(self, uri):
+        if uri == self.external_uri or uri in self.local_uri:
             return True
-
-        printDebug.debug("Checking [%s:%s] against [%s:%s]" % ( ipaddress, port, self.external_address, self.external_port))
-        if "%s:%s" % (ipaddress, port) == "%s:%s" %(self.external_address, self.external_port):
-            return True
-
-        for test_address in self.local_address:
-            printDebug.debug("Checking [%s:%s] against [%s:%s]" % ( ipaddress, port, ipaddress, 32400 ))
-            if "%s:%s" % (ipaddress, port) == "%s:%s" % (test_address, 32400):
-                return True
 
         return False
 
@@ -232,17 +187,17 @@ class PlexMediaServer:
             start_time=time.time()
             try:
                 if type == 'get':
-                    response = requests.get("%s://%s:%s%s" % (self.protocol, self.get_address(), self.get_port(), url), params=self.plex_identification_header, timeout=(2,60))
+                    response = requests.get("%s%s" % (self.get_uri(), url), params=self.plex_identification_header, timeout=(2,60))
                 elif type == 'put':
-                    response = requests.put("%s://%s:%s%s" % (self.protocol, self.get_address(), self.get_port(), url), params=self.plex_identification_header, timeout=(2,60))                
+                    response = requests.put("%s%s" % (self.get_uri(), url), params=self.plex_identification_header, timeout=(2,60))                
                 elif type == 'delete':
-                    response = requests.delete("%s://%s:%s%s" % (self.protocol, self.get_address(), self.get_port(), url), params=self.plex_identification_header, timeout=(2,60))              
+                    response = requests.delete("%s%s" % (self.get_uri(), url), params=self.plex_identification_header, timeout=(2,60))              
                 self.offline=False
             except requests.exceptions.ConnectionError, e:
-                printDebug.error("Server: %s is offline or uncontactable. error: %s" % (self.get_address(), e))
+                printDebug.error("Server: %s is offline or uncontactable. error: %s" % (self.get_uri(), e))
                 self.offline=True
             except requests.exceptions.ReadTimeout, e:
-                printDebug.info("Server: read timeout for %s on %s " % (self.get_address(), url))
+                printDebug.info("Server: read timeout for %s on %s " % (self.get_uri(), url))
             else:
 
                 printDebug.debug("URL was: %s" % response.url)
@@ -252,7 +207,7 @@ class PlexMediaServer:
                     printDebug.debugplus("===XML===\n%s\n===XML===" % response.text.encode('utf-8'))
                     data = response.text.encode('utf-8')
 
-                    printDebug.info("DOWNLOAD: It took %.2f seconds to retrieve data from %s" % ((time.time() - start_time), self.get_address()))                   
+                    printDebug.info("DOWNLOAD: It took %.2f seconds to retrieve data from %s" % ((time.time() - start_time), self.get_uri()))                   
                     return data
                 elif response.status_code == requests.codes.unauthorized:
                     printDebug.debug("Response: 401 Unauthorized - Please log into myplex or check your myplex password")                                        
@@ -341,7 +296,7 @@ class PlexMediaServer:
         data = self.talk(url)
         start_time=time.time()
         tree = etree.fromstring(data)
-        printDebug.info("PARSE: it took %.2f seconds to parse data from %s" % ((time.time() - start_time), self.get_address()))
+        printDebug.info("PARSE: it took %.2f seconds to parse data from %s" % ((time.time() - start_time), self.get_uri()))
         return tree
 
     def raw_xml(self,url):
@@ -357,7 +312,7 @@ class PlexMediaServer:
 
         data = self.talk(url)
 
-        printDebug.info("PROCESSING: it took %.2f seconds to process data from %s" % ((time.time() - start_time), self.get_address()))
+        printDebug.info("PROCESSING: it took %.2f seconds to process data from %s" % ((time.time() - start_time), self.get_uri()))
         return data
 
     def is_owned(self):

--- a/resources/lib/plexserver.py
+++ b/resources/lib/plexserver.py
@@ -135,8 +135,14 @@ class PlexMediaServer:
     def set_local_uri(self, uris):
         self.local_uri=uris
 
-    def set_best_address(self, uri):
+    def set_best_uri(self, uri):
         self.access_uri = uri
+
+    def is_encrypted(self):
+        if self.external_uri is not None and self.external_uri.startswith('https'):
+            return True
+        else:
+            return False
 
     def find_uri_match(self, uri):
         if uri == self.external_uri or uri in self.local_uri:


### PR DESCRIPTION
This adds support for encrypted Plex servers (0.9.12.3 and later).

Successfully tested with:
- unencrypted Plex server (myplex)
- encrypted Plex server (myplex)
- manual connection unencrypted Plex server

Untested:
- GDM discovered unencrypted Plex servers (discovery failed to detect any servers for unknown reasons)

Note, that I had to switch to another API call (https://plex.tv/api/resources.xml?includeHttps=1) to get the correct server URIs. I don't know when that API was added, so this patch might break support with older Plex servers.
