### PR TITLE
Added FQDN support for Plex server address

### DIFF
--- a/resources/lib/plex.py
+++ b/resources/lib/plex.py
@@ -10,6 +10,7 @@ import requests
 from plexserver import PlexMediaServer
 import urlparse
 import uuid
+import socket
 
 printDebug=printDebug("PleXBMC", "plex")
 DEFAULT_PORT="32400"
@@ -490,6 +491,9 @@ class Plex:
         if ':' in ip:
             #We probably have an IP:port being passed
             ip, port = ip.split(':')
+
+        if not is_ip(ip):
+            ip = socket.gethostbyname(ip)
 
         if not is_ip(ip):
             printDebug.info("Not an IP Address")


### PR DESCRIPTION
This is my first look at the code of PlexBMC. Following an upgrade from XBMC the plugin never worked for me when communicating to a Plex server on the local network. Looks like it has issues when the Plex server reports its FQDN, seems it only expects the IP address. I hope this patch is useful, otherwise let me know your thoughts if you think there's a better way. I spent a couple of hours attempting to understand why the plexbmc plugin gave terrible trouble getting setup on a fresh install and appeared flaky and wouldn't list any media, and why the helper wouldn't play anything at all. This patch has got me working.
