### PR TITLE
Add disc number info to music tags / fix music sorting

### DIFF
--- a/resources/lib/plexbmc.py
+++ b/resources/lib/plexbmc.py
@@ -983,6 +983,7 @@ def get_audio_subtitles_from_media(server, tree, full=False):
         elif media_type == "music":
 
             full_data={'TrackNumber' : int(timings.get('index',0)) ,
+                       'discnumber'  : int(timings.get('parentIndex',0)) ,
                        'title'       : str(timings.get('index',0)).zfill(2)+". "+timings.get('title','Unknown').encode('utf-8') ,
                        'rating'      : float(timings.get('rating',0)) ,
                        'album'       : timings.get('parentTitle', tree.get('parentTitle','')).encode('utf-8') ,
@@ -2194,6 +2195,7 @@ def track_tag(server, tree, track, sectionart="", sectionthumb="", listing=True)
     log_print.debug( "Part is %s" % partDetails)
 
     details={'TrackNumber' : int(track.get('index',0)) ,
+             'discnumber'  : int(track.get('parentIndex',0)) ,
              'title'       : str(track.get('index',0)).zfill(2)+". "+track.get('title','Unknown').encode('utf-8') ,
              'rating'      : float(track.get('rating',0)) ,
              'album'       : track.get('parentTitle', tree.get('parentTitle','')).encode('utf-8') ,


### PR DESCRIPTION
This adds the disc number information, and fixes track sorting.

When sorting by Track, songs with the same track number, but different disc number would appear together ie:
01. Track 01 from Disc 1
01. Track 01 from Disc 2
02. Track 02 from Disc 1
02. Track 02 from Disc 2
...
