### PR TITLE
Explicitly send X-Plex-Token as URL parameter (Kodi 17.0b6-Krypton)

### DIFF
--- a/resources/lib/plex/plexserver.py
+++ b/resources/lib/plex/plexserver.py
@@ -450,6 +450,9 @@ class PlexMediaServer:
         query_args = urlparse.parse_qsl(url_parts.query)
         query_args += options.items()
 
+        if self.token is not None:
+            query_args += { 'X-Plex-Token' : self.token }.items()
+
         new_query_args = urllib.urlencode(query_args, True)
 
         return "%s | %s" % (urlparse.urlunparse((url_parts.scheme, url_parts.netloc, url_parts.path, url_parts.params, new_query_args, url_parts.fragment)), self.plex_identification_string)

--- a/resources/lib/plexbmc.py
+++ b/resources/lib/plexbmc.py
@@ -530,14 +530,14 @@ def process_movies(url, tree=None):
     log_print.debug("== ENTER ==")
     xbmcplugin.setContent(pluginhandle, 'movies')
 
-    xbmcplugin.addSortMethod(pluginhandle, 37)  # maintain original plex sorted
-    xbmcplugin.addSortMethod(pluginhandle, 25)  # video title ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 19)  # date added
-    xbmcplugin.addSortMethod(pluginhandle, 3)   # date
-    xbmcplugin.addSortMethod(pluginhandle, 18)  # rating
-    xbmcplugin.addSortMethod(pluginhandle, 17)  # year
-    xbmcplugin.addSortMethod(pluginhandle, 29)  # runtime
-    xbmcplugin.addSortMethod(pluginhandle, 28)  # by MPAA
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_DATEADDED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_DATE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_RATING)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_RUNTIME)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_MPAA_RATING)
 
     # get the server name from the URL, which was passed via the on screen listing..
 
@@ -591,12 +591,12 @@ def build_context_menu(url, item_data, server):
 def process_tvshows(url, tree=None):
     log_print.debug("== ENTER ==")
     xbmcplugin.setContent(pluginhandle, 'tvshows')
-    xbmcplugin.addSortMethod(pluginhandle, 37 ) # maintain original plex sorted
-    xbmcplugin.addSortMethod(pluginhandle, 25 ) # video title ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 3 )  # date
-    xbmcplugin.addSortMethod(pluginhandle, 18 ) # rating
-    xbmcplugin.addSortMethod(pluginhandle, 17 ) # year
-    xbmcplugin.addSortMethod(pluginhandle, 28 ) # by MPAA
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_DATE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_RATING)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_MPAA_RATING)
 
     # Get the URL and server name.  Get the XML and parse
     tree = get_xml(url,tree)
@@ -791,18 +791,18 @@ def process_tvepisodes(url, tree=None):
 
     if tree.get('mixedParents') == '1':
         log_print.info('Setting plex sort')
-        xbmcplugin.addSortMethod(pluginhandle, 37 ) # maintain original plex sorted
+        xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_UNSORTED ) # maintain original plex sorted
     else:
         log_print.info('Setting KODI sort')
         xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_EPISODE )  # episode
 
-    xbmcplugin.addSortMethod(pluginhandle, 3 )  # date
-    xbmcplugin.addSortMethod(pluginhandle, 25 ) # video title ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 19 )  # date added
-    xbmcplugin.addSortMethod(pluginhandle, 18 ) # rating
-    xbmcplugin.addSortMethod(pluginhandle, 17 ) # year
-    xbmcplugin.addSortMethod(pluginhandle, 29 ) # runtime
-    xbmcplugin.addSortMethod(pluginhandle, 28 ) # by MPAA    
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_DATE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_DATEADDED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_RATING)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_RUNTIME)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_MPAA_RATING)
 
     for episode in ShowTags:
 
@@ -1720,10 +1720,10 @@ def artist(url, tree=None):
     '''
     log_print.debug("== ENTER ==")
     xbmcplugin.setContent(pluginhandle, 'artists')
-    xbmcplugin.addSortMethod(pluginhandle, 37 ) # maintain original plex sorted
-    xbmcplugin.addSortMethod(pluginhandle, 12 ) # artist title ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 34 ) # last played
-    xbmcplugin.addSortMethod(pluginhandle, 17 ) # year
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_ARTIST_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_LASTPLAYED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
 
     # Get the URL and server name.  Get the XML and parse
     tree=get_xml(url,tree)
@@ -1762,11 +1762,11 @@ def artist(url, tree=None):
 def albums(url, tree=None):
     log_print.debug("== ENTER ==")
     xbmcplugin.setContent(pluginhandle, 'albums')
-    xbmcplugin.addSortMethod(pluginhandle, 37 ) # maintain original plex sorted
-    xbmcplugin.addSortMethod(pluginhandle, 24 ) # album title ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 12 )  # artist ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 34 ) # last played
-    xbmcplugin.addSortMethod(pluginhandle, 17 ) # year
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_ALBUM_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_ARTIST_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_LASTPLAYED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
 
     # Get the URL and server name.  Get the XML and parse
     tree=get_xml(url,tree)
@@ -1814,11 +1814,11 @@ def albums(url, tree=None):
 def tracks(url, tree=None):
     log_print.debug("== ENTER ==")
     xbmcplugin.setContent(pluginhandle, 'songs')
-    xbmcplugin.addSortMethod(pluginhandle, 37 ) # maintain original plex sorted
-    xbmcplugin.addSortMethod(pluginhandle, 10 ) # title title ignore THE
-    xbmcplugin.addSortMethod(pluginhandle, 8 ) # duration
-    xbmcplugin.addSortMethod(pluginhandle, 27 ) # song rating
-    xbmcplugin.addSortMethod(pluginhandle, 7 ) # track number
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_DURATION)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_SONG_RATING)
+    xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_TRACKNUM)
 
     tree=get_xml(url,tree)
     if tree is None:

--- a/resources/lib/plexbmc.py
+++ b/resources/lib/plexbmc.py
@@ -983,6 +983,7 @@ def get_audio_subtitles_from_media(server, tree, full=False):
         elif media_type == "music":
 
             full_data={'TrackNumber' : int(timings.get('index',0)) ,
+                       'discnumber'  : int(timings.get('parentIndex',0)) ,
                        'title'       : str(timings.get('index',0)).zfill(2)+". "+timings.get('title','Unknown').encode('utf-8') ,
                        'rating'      : float(timings.get('rating',0)) ,
                        'album'       : timings.get('parentTitle', tree.get('parentTitle','')).encode('utf-8') ,
@@ -2194,6 +2195,7 @@ def track_tag(server, tree, track, sectionart="", sectionthumb="", listing=True)
     log_print.debug( "Part is %s" % partDetails)
 
     details={'TrackNumber' : int(track.get('index',0)) ,
+             'discnumber'  : int(track.get('parentIndex',0)) ,
              'title'       : str(track.get('index',0)).zfill(2)+". "+track.get('title','Unknown').encode('utf-8') ,
              'rating'      : float(track.get('rating',0)) ,
              'album'       : track.get('parentTitle', tree.get('parentTitle','')).encode('utf-8') ,


### PR DESCRIPTION
As of Kodi 17.0b6-Krypton [1], curl will no longer send all headers blindly. 

This results in (at least) thumbnails not loading, and errors:
```
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option ' X-Plex-Platform: KODI'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Client-Identifier: ...'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Client-Platform: KODI'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Device: PleXBMC'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Device-Name: My PleXBMC Client'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Language: en'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Model: unknown'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Platform-Version: Windows'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Product: PleXBMC'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Provides: player'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Token: ...'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-User: ...'
DEBUG: CurlFile::ParseAndCorrectUrl() ignoring header option 'X-Plex-Version: 4.1.0'
ERROR: CCurlFile::Stat - Failed: HTTP response code said error(22) for https://192.168.1.2:32400/photo/:/transcode?url=http%3A%2F%2Flocalhost%3A32400%2Flibrary%2Fmetadata%2F3%2Fthumb%2F1427952599&width=720&height=720 | X-Plex-Platform=KODI&X-Plex-Client-Platform=KODI&X-Plex-User=...&X-Plex-Device-Name=My%20PleXBMC%20Client&X-Plex-Provides=player&X-Plex-Token=...&X-Plex-Model=unknown&X-Plex-Platform-Version=Windows&X-Plex-Client-Identifier=...&X-Plex-Device=PleXBMC&X-Plex-Product=PleXBMC&X-Plex-Language=en&X-Plex-Version=4.1.0
```

This patch adds the token as a URL Parameter [2] of the URL returned from get_kodi_header_formatted_url

Not sure if this is the correct branch to base this pull request on.

References:
[1] https://github.com/xbmc/xbmc/commit/ed00cd660dbbd40cb678b5b3ddfce569bf31bb85
[2] https://support.plex.tv/hc/en-us/articles/204059436-Finding-your-account-token-X-Plex-Token